### PR TITLE
Add generic client

### DIFF
--- a/operatortrace-go/pkg/client/generic_client.go
+++ b/operatortrace-go/pkg/client/generic_client.go
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// pkg/client/genericclient.go
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	constants "github.com/Azure/operatortrace/operatortrace-go/pkg/constants"
+	tracingtypes "github.com/Azure/operatortrace/operatortrace-go/pkg/types"
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/trace"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+type GenericClient interface {
+	StartTrace(ctx context.Context, obj client.Object) (context.Context, trace.Span, error)
+	EndTrace(ctx context.Context, obj client.Object) error
+	StartSpan(ctx context.Context, operationName string) (context.Context, trace.Span)
+	SetSpan(ctx context.Context, obj client.Object) (context.Context, trace.Span)
+}
+
+// genericClient wraps the trace.Tracer to provide helper methods for tracing kubernetes objects.
+type genericClient struct {
+	trace.Tracer
+	logr.Logger
+	scheme *runtime.Scheme
+}
+
+// NewTracingClient initializes and returns a new TracingClient
+// optional scheme.  If not, it will use client-go scheme
+func NewGenericClient(t trace.Tracer, l logr.Logger, scheme ...*runtime.Scheme) GenericClient {
+	tracingScheme := clientgoscheme.Scheme
+	if len(scheme) > 0 {
+		tracingScheme = scheme[0]
+	}
+
+	return &genericClient{
+		Tracer: t,
+		Logger: l,
+		scheme: tracingScheme,
+	}
+}
+
+// StartTrace starts a new trace span from the given object.
+func (gc *genericClient) StartTrace(ctx context.Context, obj client.Object) (context.Context, trace.Span, error) {
+	linkedSpans := [10]tracingtypes.LinkedSpan{}
+
+	gvk, err := apiutil.GVKForObject(obj, gc.scheme)
+	objectName := obj.GetName()
+	objectKind := ""
+	if err == nil {
+		objectKind = gvk.GroupKind().Kind
+	}
+
+	ctx, span := startSpanFromContext(ctx, gc.Logger, gc.Tracer, obj, gc.scheme, fmt.Sprintf("StartTrace %s %s", objectKind, objectName), linkedSpans)
+	if err != nil {
+		span.RecordError(err)
+	}
+
+	gc.Logger.Info("Getting object", "object", objectName)
+	return trace.ContextWithSpan(ctx, span), span, err
+}
+
+// EndTrace ends the trace span for the given object.
+func (gc *genericClient) EndTrace(ctx context.Context, obj client.Object) error {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return nil
+	}
+
+	delete(annotations, constants.TraceIDAnnotation)
+	delete(annotations, constants.SpanIDAnnotation)
+	delete(annotations, constants.TraceIDTimeAnnotation)
+	obj.SetAnnotations(annotations)
+
+	return nil
+}
+
+func (gc *genericClient) StartSpan(ctx context.Context, operationName string) (context.Context, trace.Span) {
+	return startSpanFromContext(ctx, gc.Logger, gc.Tracer, nil, gc.scheme, operationName, [10]tracingtypes.LinkedSpan{})
+}
+
+func (gc *genericClient) SetSpan(ctx context.Context, obj client.Object) (context.Context, trace.Span) {
+	ctx, span := startSpanFromContextGeneric(ctx, gc.Logger, gc.Tracer, obj.GetName())
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	annotations[constants.TraceIDAnnotation] = span.SpanContext().TraceID().String()
+	annotations[constants.SpanIDAnnotation] = span.SpanContext().SpanID().String()
+	annotations[constants.TraceIDTimeAnnotation] = time.Now().Format(time.RFC3339)
+	obj.SetAnnotations(annotations)
+
+	return trace.ContextWithSpan(ctx, span), span
+}

--- a/operatortrace-go/pkg/client/generic_client_test.go
+++ b/operatortrace-go/pkg/client/generic_client_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// pkg/client/generic_client_test.go
+
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Azure/operatortrace/operatortrace-go/pkg/constants"
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func initGenericTracer() trace.Tracer {
+	exporter, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
+	if err != nil {
+		panic(err)
+	}
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+	)
+	otel.SetTracerProvider(tp)
+	return tp.Tracer("operatortrace-generic")
+}
+
+func TestNewGenericClient(t *testing.T) {
+	tracer := initGenericTracer()
+	logger := logr.Discard()
+	client := NewGenericClient(tracer, logger)
+	assert.NotNil(t, client)
+}
+
+func TestGenericClientStartTraceAndEndTrace(t *testing.T) {
+	tracer := initGenericTracer()
+	logger := testr.New(t)
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	client := NewGenericClient(tracer, logger, scheme)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+	}
+	ctx := context.Background()
+	ctx, span, err := client.StartTrace(ctx, pod)
+	defer span.End()
+	assert.NoError(t, err)
+	traceID := span.SpanContext().TraceID().String()
+	spanID := span.SpanContext().SpanID().String()
+
+	// Set annotations manually to simulate SetSpan
+	annotations := pod.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[constants.TraceIDAnnotation] = traceID
+	annotations[constants.SpanIDAnnotation] = spanID
+	annotations[constants.TraceIDTimeAnnotation] = time.Now().Format(time.RFC3339)
+	pod.SetAnnotations(annotations)
+
+	err = client.EndTrace(ctx, pod)
+	assert.NoError(t, err)
+	annotations = pod.GetAnnotations()
+	assert.Empty(t, annotations[constants.TraceIDAnnotation])
+	assert.Empty(t, annotations[constants.SpanIDAnnotation])
+	assert.Empty(t, annotations[constants.TraceIDTimeAnnotation])
+}
+
+func TestGenericClientStartSpan(t *testing.T) {
+	tracer := initGenericTracer()
+	logger := logr.Discard()
+	scheme := runtime.NewScheme()
+	client := NewGenericClient(tracer, logger, scheme)
+	ctx := context.Background()
+	_, span := client.StartSpan(ctx, "TestOperation")
+	defer span.End()
+	assert.NotNil(t, span)
+}
+
+func TestGenericClientSetSpan(t *testing.T) {
+	tracer := initGenericTracer()
+	logger := logr.Discard()
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	client := NewGenericClient(tracer, logger, scheme)
+	ctx := context.Background()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+	}
+	_, span := client.SetSpan(ctx, pod)
+	defer span.End()
+	annotations := pod.GetAnnotations()
+	assert.NotEmpty(t, annotations[constants.TraceIDAnnotation])
+	assert.NotEmpty(t, annotations[constants.SpanIDAnnotation])
+	assert.NotEmpty(t, annotations[constants.TraceIDTimeAnnotation])
+}

--- a/operatortrace-go/pkg/client/span_helpers.go
+++ b/operatortrace-go/pkg/client/span_helpers.go
@@ -137,7 +137,7 @@ func startSpanFromContext(ctx context.Context, logger logr.Logger, tracer trace.
 	return ctx, span
 }
 
-func startSpanFromContextList(ctx context.Context, logger logr.Logger, tracer trace.Tracer, obj client.ObjectList, operationName string) (context.Context, trace.Span) {
+func startSpanFromContextGeneric(ctx context.Context, logger logr.Logger, tracer trace.Tracer, operationName string) (context.Context, trace.Span) {
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		spanContext := trace.NewSpanContext(trace.SpanContextConfig{

--- a/operatortrace-go/pkg/client/span_helpers.go
+++ b/operatortrace-go/pkg/client/span_helpers.go
@@ -141,8 +141,10 @@ func startSpanFromContextGeneric(ctx context.Context, logger logr.Logger, tracer
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		spanContext := trace.NewSpanContext(trace.SpanContextConfig{
-			TraceID: span.SpanContext().TraceID(),
-			SpanID:  span.SpanContext().SpanID(),
+			TraceID:    span.SpanContext().TraceID(),
+			SpanID:     span.SpanContext().SpanID(),
+			TraceFlags: trace.FlagsSampled,
+			Remote:     false,
 		})
 		ctx = trace.ContextWithRemoteSpanContext(ctx, spanContext)
 		ctx, span = tracer.Start(ctx, operationName)

--- a/operatortrace-go/pkg/client/tracing_client_test.go
+++ b/operatortrace-go/pkg/client/tracing_client_test.go
@@ -598,7 +598,7 @@ func TestEndTrace(t *testing.T) {
 	assert.Equal(t, len(spanID), len(retrievedPod.Annotations[constants.SpanIDAnnotation]))
 
 	// Test EndTrace
-	_, err = tracingClient.EndTrace(ctx, retrievedPod)
+	err = tracingClient.EndTrace(ctx, retrievedPod)
 	assert.NoError(t, err)
 	finalPod := &corev1.Pod{}
 	// Get the pod with default kubernetes client to ensure that there is no traceID and spanID
@@ -677,7 +677,7 @@ func TestEndTraceChangedAnnotation(t *testing.T) {
 	tracingClientNew.Update(ctxNew, retrievedPodClone)
 
 	// Test EndTrace and ensure that it did not remove the traceID since it was updated by a different client
-	_, err = tracingClient.EndTrace(ctx, retrievedPod)
+	err = tracingClient.EndTrace(ctx, retrievedPod)
 	assert.NoError(t, err)
 	finalPod := &corev1.Pod{}
 	// Get the pod with default kubernetes client to ensure that there is no traceID and spanID

--- a/operatortrace-go/pkg/client/tracing_interface.go
+++ b/operatortrace-go/pkg/client/tracing_interface.go
@@ -18,7 +18,7 @@ type TracingClient interface {
 	trace.Tracer
 
 	StartTrace(ctx context.Context, requestWithTraceID *tracingtypes.RequestWithTraceID, obj client.Object, opts ...client.GetOption) (context.Context, trace.Span, error)
-	EndTrace(ctx context.Context, obj client.Object, opts ...client.PatchOption) (client.Object, error)
+	EndTrace(ctx context.Context, obj client.Object, opts ...client.PatchOption) error
 	StartSpan(ctx context.Context, operationName string) (context.Context, trace.Span)
 	EmbedTraceIDInRequest(requestWithTraceID *tracingtypes.RequestWithTraceID, obj client.Object) error
 }

--- a/operatortrace-go/pkg/reconcile/reconcile.go
+++ b/operatortrace-go/pkg/reconcile/reconcile.go
@@ -56,6 +56,11 @@ func (a *objectReconcilerAdapter[T]) Reconcile(ctx context.Context, req tracingt
 
 	result, err := a.objReconciler.Reconcile(ctx, o)
 
+	if err != nil {
+		// Record the error in the span
+		span.RecordError(err)
+	}
+
 	// errors from EndTrace are recorded in the span
 	a.client.EndTrace(ctx, o)
 

--- a/operatortrace-go/pkg/reconcile/reconcile.go
+++ b/operatortrace-go/pkg/reconcile/reconcile.go
@@ -39,8 +39,9 @@ func AsTracingReconciler[T ctrlclient.Object](client tracingclient.TracingClient
 
 // objectReconcilerAdapter is the object for creating a reconcile request as a converted object.
 type objectReconcilerAdapter[T ctrlclient.Object] struct {
-	objReconciler ctrlreconcile.ObjectReconciler[T]
-	client        tracingclient.TracingClient
+	objReconciler   ctrlreconcile.ObjectReconciler[T]
+	client          tracingclient.TracingClient
+	disableEndTrace bool // If true, the EndTrace call is NOT made at the end of Reconcile. (default is false - EndTrace is called)
 }
 
 // Reconcile implements Reconciler.
@@ -61,8 +62,10 @@ func (a *objectReconcilerAdapter[T]) Reconcile(ctx context.Context, req tracingt
 		span.RecordError(err)
 	}
 
-	// errors from EndTrace are recorded in the span
-	a.client.EndTrace(ctx, o)
+	if a.disableEndTrace {
+		// errors from EndTrace are recorded in the span
+		a.client.EndTrace(ctx, o)
+	}
 
 	return result, err
 }

--- a/operatortrace-go/pkg/tracingqueue/tracingqueue.go
+++ b/operatortrace-go/pkg/tracingqueue/tracingqueue.go
@@ -111,7 +111,13 @@ func (tq *TracingQueue) Get() (req tracingtypes.RequestWithTraceID, shutdown boo
 	}
 
 	tq.mu.Lock()
-	val := *tq.m[key]
+	valPtr, found := tq.m[key]
+	if !found || valPtr == nil {
+		tq.mu.Unlock()
+		// Key not found in map, return zero value
+		return tracingtypes.RequestWithTraceID{}, false
+	}
+	val := *valPtr
 	delete(tq.m, key)
 	tq.mu.Unlock()
 


### PR DESCRIPTION
implements generic client that just reads and writes to a provided object for instances where a non-client.Client implementation is used.

Also removed need for the EndTrace to return object as it already gets a pointer.