### PR TITLE
Change span types to be consumers/producers

### DIFF
--- a/operatortrace-go/pkg/client/span_helpers.go
+++ b/operatortrace-go/pkg/client/span_helpers.go
@@ -49,10 +49,10 @@ func sliceFromLinkedSpans(linkedSpans [10]types.LinkedSpan) []trace.Link {
 }
 
 // startSpanFromContext starts a new span from the context and attaches trace information to the object
-func startSpanFromContext(ctx context.Context, logger logr.Logger, tracer trace.Tracer, obj client.Object, scheme *runtime.Scheme, operationName string, linkedSpansArray [10]types.LinkedSpan) (context.Context, trace.Span) {
+func startSpanFromContext(ctx context.Context, logger logr.Logger, tracer trace.Tracer, obj client.Object, scheme *runtime.Scheme, operationName string, linkedSpansArray [10]types.LinkedSpan, spanOpts ...trace.SpanStartOption) (context.Context, trace.Span) {
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
-		ctx, span = tracer.Start(ctx, operationName)
+		ctx, span = tracer.Start(ctx, operationName, spanOpts...)
 		return ctx, span
 	}
 
@@ -132,8 +132,10 @@ func startSpanFromContext(ctx context.Context, logger logr.Logger, tracer trace.
 	// check for linked spans
 	linkedSpans := sliceFromLinkedSpans(linkedSpansArray)
 
+	spanOpts = append(spanOpts, trace.WithLinks(linkedSpans...))
+
 	// Create a new span
-	ctx, span = tracer.Start(ctx, operationName, trace.WithLinks(linkedSpans...))
+	ctx, span = tracer.Start(ctx, operationName, spanOpts...)
 	return ctx, span
 }
 

--- a/operatortrace-go/pkg/client/tracing_client_test.go
+++ b/operatortrace-go/pkg/client/tracing_client_test.go
@@ -18,7 +18,6 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -749,6 +748,7 @@ func TestDeleteWithTracing(t *testing.T) {
 	defer span.End()
 	assert.NoError(t, err)
 	traceID := span.SpanContext().TraceID().String()
+	assert.NotEmpty(t, traceID)
 
 	// Retrieve the Pod and check the annotation
 	err = tracingClient.Delete(ctx, pod)
@@ -784,6 +784,7 @@ func TestDeleteAllOfWithTracing(t *testing.T) {
 	defer span.End()
 	assert.NoError(t, err)
 	traceID := span.SpanContext().TraceID().String()
+	assert.NotEmpty(t, traceID)
 
 	// Retrieve the Pod and check the annotation
 	retrievedPod := &corev1.Pod{}
@@ -822,7 +823,7 @@ func TestGetConditions(t *testing.T) {
 	// Assert no error occurred
 	assert.NoError(t, err)
 
-	assert.Equal(t, conditions[0]["Type"], v1.PodConditionType("PodScheduled"))
+	assert.Equal(t, conditions[0]["Type"], corev1.PodConditionType("PodScheduled"))
 }
 
 func TestGetConditionMessage(t *testing.T) {

--- a/operatortrace-go/pkg/helpers/start_span.go
+++ b/operatortrace-go/pkg/helpers/start_span.go
@@ -9,19 +9,14 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func StartSpan(ctx context.Context, tracer trace.Tracer, operationName string) (context.Context, trace.Span) {
+func StartSpan(ctx context.Context, tracer trace.Tracer, operationName string, spanOpts ...trace.SpanStartOption) (context.Context, trace.Span) {
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
-		spanContext := trace.NewSpanContext(trace.SpanContextConfig{
-			TraceID: span.SpanContext().TraceID(),
-			SpanID:  span.SpanContext().SpanID(),
-		})
-		ctx = trace.ContextWithRemoteSpanContext(ctx, spanContext)
-		ctx, span = tracer.Start(ctx, operationName)
+		ctx, span = tracer.Start(ctx, operationName, spanOpts...)
 		return ctx, span
 	}
 
 	// If there is no span in the context, create a new one
-	ctx, span = tracer.Start(ctx, operationName)
+	ctx, span = tracer.Start(ctx, operationName, spanOpts...)
 	return ctx, span
 }


### PR DESCRIPTION
Currently, all of the spans were marked as Internal which can get filtered out. This will help persist that the startTrace events or events that do any action against the Kubernetes API will be marked as Consumer/Producer spans.